### PR TITLE
Stop building a wheel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ view: doc
 	open doc/build/html/index.html
 
 clean:
-	-rm -r build/
+	-rm -r build/ dist/
 	-rm -r saftig/__pycache__/
 	-rm *.so
 	-rm saftig/*.so
@@ -32,7 +32,7 @@ clean:
 	-rm -r htmlcov
 
 testpublish:
-	python -m build
+	python -m build -s
 	twine upload --repository testpypi dist/*
 
 .PHONY: all, doc, view, test, linter, coverage, cweb, linter_testing, lt, build, clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = ["setuptools",
-    "wheel",
     "numpy",
     "scipy",
     "matplotlib",


### PR DESCRIPTION
Building compiled packages is much more complicated than I expected, so let's just not do it.