### PR TITLE
Disable wheel building for now.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build release distributions
         run: |
           python -m pip install build
-          python -m build
+          python -m build -s
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Building acceptable wheels with compiled C extensions is more complicated and requires a different CI setup. Maybe later.